### PR TITLE
feat: Add AWS provider configuration and input variables

### DIFF
--- a/examples/security-group-v2/basic/.terraform-docs.yml
+++ b/examples/security-group-v2/basic/.terraform-docs.yml
@@ -1,0 +1,10 @@
+---
+formatter: markdown table
+
+output:
+    file: README.md
+    mode: inject
+    template: |-
+        <!-- BEGIN_TF_DOCS -->
+        {{ .Content }}
+        <!-- END_TF_DOCS -->

--- a/examples/security-group-v2/basic/README.md
+++ b/examples/security-group-v2/basic/README.md
@@ -1,0 +1,46 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.48.0, < 5.0.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_main_module"></a> [main\_module](#module\_main\_module) | ../../../modules/security-group | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | n/a | yes |
+| <a name="input_is_enabled"></a> [is\_enabled](#input\_is\_enabled) | Enable or disable the module | `bool` | n/a | yes |
+| <a name="input_security_group_config"></a> [security\_group\_config](#input\_security\_group\_config) | A list of objects that contains the configuration for the security groups.<br>This configuration includes the main configuration for the security group. The following<br>attributes are supported:<br>- name: The name of the security group.<br>- description: The description of the security group.<br>- vpc\_id: The VPC ID to create the security group in. | <pre>list(object({<br>    name        = string<br>    description = optional(string, null)<br>    vpc_id      = string<br>  }))</pre> | `null` | no |
+| <a name="input_security_group_rules"></a> [security\_group\_rules](#input\_security\_group\_rules) | A list of objects that contains the configuration for the security groups.<br>If set, it'll relate the sg\_name with the 'name' attribute passed into the<br>variable 'security\_group\_config'. The following attributes are supported:<br>- sg\_parent: The name of the security group.<br>- sg\_rules: An object that contains the configuration for the security group rules. | <pre>list(object({<br>    sg_parent        = string<br>    type             = string<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = optional(list(string), null)<br>    ipv6_cidr_blocks = optional(list(string), null)<br>    prefix_list_ids  = optional(list(string), null)<br>    self             = optional(bool, false)<br>    description      = optional(string, null)<br>  }))</pre> | `null` | no |
+| <a name="input_security_group_rules_ooo"></a> [security\_group\_rules\_ooo](#input\_security\_group\_rules\_ooo) | A list of objects that contains the configuration for the security groups, and that normally<br>used in the context of ALB, testing traffic for ICMP packages, and other common use-cases<br>It can be used as an alternative of the values that are set in the variable 'security\_group\_rules'.<br>If set, it'll relate the sg\_name with the 'name' attribute passed into the<br>variable 'security\_group\_config'. The following attributes are supported:<br>- sg\_parent: The name of the security group.<br>- enable\_inbound\_http: Whether to enable inbound HTTP traffic or not.<br>- enable\_inbound\_https: Whether to enable inbound HTTPS traffic or not.<br>- enable\_inbound\_ssh: Whether to enable inbound SSH traffic or not.<br>- enable\_inbound\_icmp: Whether to enable inbound ICMP traffic or not. | <pre>list(object({<br>    sg_parent            = string<br>    enable_inbound_http  = optional(bool, false)<br>    enable_inbound_https = optional(bool, false)<br>    enable_inbound_ssh   = optional(bool, false)<br>    enable_inbound_icmp  = optional(bool, false)<br>  }))</pre> | `null` | no |
+| <a name="input_vpc_lookup_config"></a> [vpc\_lookup\_config](#input\_vpc\_lookup\_config) | This object works in ocnjunction with the variable 'security\_group\_config' to<br>lookup the VPC ID to create the security group in. The following attributes are supported:<br>- vpc\_name: The name of the VPC to lookup.<br>- is\_default\_vpc\_enabled: Whether to lookup the default VPC or not. | <pre>object({<br>    vpc_name               = optional(string, null)<br>    is_default_vpc_enabled = optional(bool, false)<br>  })</pre> | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_region_for_deploy_this"></a> [aws\_region\_for\_deploy\_this](#output\_aws\_region\_for\_deploy\_this) | The AWS region where the module is deployed. |
+| <a name="output_is_enabled"></a> [is\_enabled](#output\_is\_enabled) | Whether the module is enabled or not. |
+| <a name="output_sg_arn"></a> [sg\_arn](#output\_sg\_arn) | The ARNs of the security groups that this module creates. |
+| <a name="output_sg_description"></a> [sg\_description](#output\_sg\_description) | The descriptions of the security groups that this module creates. |
+| <a name="output_sg_id"></a> [sg\_id](#output\_sg\_id) | The security groups that this module creates. |
+| <a name="output_sg_name"></a> [sg\_name](#output\_sg\_name) | The names of the security groups that this module creates. |
+| <a name="output_sg_vpc_id"></a> [sg\_vpc\_id](#output\_sg\_vpc\_id) | The VPC IDs of the security groups that this module creates. |
+<!-- END_TF_DOCS -->

--- a/examples/security-group-v2/basic/config/fixtures.tfvars
+++ b/examples/security-group-v2/basic/config/fixtures.tfvars
@@ -1,0 +1,10 @@
+aws_region = "us-east-1"
+is_enabled = true
+
+security_group_config = [
+  {
+    name        = "firewall-test-1"
+    description = "my sg that i am testing"
+    vpc_id      = "vpc-1234567890"
+  }
+]

--- a/examples/security-group-v2/basic/main.tf
+++ b/examples/security-group-v2/basic/main.tf
@@ -1,0 +1,4 @@
+module "main_module" {
+  source                   = "../../../modules/security-group-v2"
+  is_enabled               = var.is_enabled
+}

--- a/examples/security-group-v2/basic/outputs.tf
+++ b/examples/security-group-v2/basic/outputs.tf
@@ -1,0 +1,39 @@
+output "is_enabled" {
+  value       = var.is_enabled
+  description = "Whether the module is enabled or not."
+}
+
+output "aws_region_for_deploy_this" {
+  value       = module.main_module.aws_region_for_deploy_this
+  description = "The AWS region where the module is deployed."
+}
+
+/*
+-------------------------------------
+Custom outputs
+-------------------------------------
+*/
+output "sg_id" {
+  value       = module.main_module.sg_id
+  description = "The security groups that this module creates."
+}
+
+output "sg_arn" {
+  value       = module.main_module.sg_arn
+  description = "The ARNs of the security groups that this module creates."
+}
+
+output "sg_name" {
+  value       = module.main_module.sg_name
+  description = "The names of the security groups that this module creates."
+}
+
+output "sg_description" {
+  value       = module.main_module.sg_description
+  description = "The descriptions of the security groups that this module creates."
+}
+
+output "sg_vpc_id" {
+  value       = module.main_module.sg_vpc_id
+  description = "The VPC IDs of the security groups that this module creates."
+}

--- a/examples/security-group-v2/basic/providers.tf
+++ b/examples/security-group-v2/basic/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/examples/security-group-v2/basic/variables.tf
+++ b/examples/security-group-v2/basic/variables.tf
@@ -1,0 +1,148 @@
+variable "is_enabled" {
+  type        = bool
+  description = <<EOF
+  Whether this module will be created or not. It is useful, for stack-composite
+modules that conditionally includes resources provided by this module..
+EOF
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region to deploy the resources"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to add to all resources."
+  default     = {}
+}
+
+/*
+-------------------------------------
+Custom input variables
+-------------------------------------
+*/
+variable "security_group_config" {
+  type = list(object({
+    name        = string
+    description = optional(string, null)
+    vpc_id      = optional(string, null)
+  }))
+  description = <<EOF
+  A list of objects that contains the configuration for the security groups.
+This configuration includes the main configuration for the security group. The following
+attributes are supported:
+- name: The name of the security group.
+- description: The description of the security group.
+- vpc_id: The VPC ID to create the security group in.
+  EOF
+  default     = null
+}
+
+variable "security_group_rules" {
+  type = list(object({
+    sg_parent                = string
+    type                     = string
+    from_port                = number
+    to_port                  = number
+    protocol                 = string
+    cidr_blocks              = optional(list(string), null)
+    ipv6_cidr_blocks         = optional(list(string), null)
+    prefix_list_ids          = optional(list(string), null)
+    self                     = optional(bool, false)
+    description              = optional(string, "no description")
+    source_security_group_id = optional(string, null)
+  }))
+  description = <<EOF
+  A list of objects that contains the configuration for the security groups.
+If set, it'll relate the sg_name with the 'name' attribute passed into the
+variable 'security_group_config'. The following attributes are supported:
+- sg_parent: The name of the security group.
+- type: The type of the security group rule. Valid values are: ingress, egress.
+- from_port: The start port of the security group rule.
+- to_port: The end port of the security group rule.
+- protocol: The protocol of the security group rule. Valid values are: tcp, udp, icmp, all.
+- cidr_blocks: The CIDR blocks to allow access from.
+- ipv6_cidr_blocks: The IPv6 CIDR blocks to allow access from.
+- prefix_list_ids: The prefix list IDs to allow access from.
+- self: Whether to allow access from the security group itself.
+- description: The description of the security group rule.
+- source_security_group_id: The ID of the security group to allow access from.
+  EOF
+  default     = null
+}
+
+variable "vpc_lookup_config" {
+  type = object({
+    vpc_name               = optional(string, null)
+    is_default_vpc_enabled = optional(bool, false)
+  })
+  description = <<EOF
+This object works in ocnjunction with the variable 'security_group_config' to
+lookup the VPC ID to create the security group in. The following attributes are supported:
+- vpc_name: The name of the VPC to lookup.
+- is_default_vpc_enabled: Whether to lookup the default VPC or not.
+  EOF
+  default     = null
+}
+
+variable "security_group_rules_ooo" {
+  type = list(object({
+    sg_parent                               = string
+    enable_all_inbound_traffic              = optional(bool, false)
+    enable_all_inbound_traffic_from_source  = optional(bool, false)
+    enable_inbound_http                     = optional(bool, false)
+    enable_inbound_from_custom_port_source  = optional(bool, false)
+    enable_inbound_from_custom_port_cidr    = optional(bool, false)
+    enable_inbound_http_from_source         = optional(bool, false)
+    enable_inbound_https                    = optional(bool, false)
+    enable_inbound_https_from_source        = optional(bool, false)
+    enable_inbound_ssh_from_anywhere        = optional(bool, false)
+    enable_inbound_ssh_from_source          = optional(bool, false)
+    enable_inbound_icmp_from_source         = optional(bool, false)
+    enable_inbound_icmp_from_anywhere       = optional(bool, false)
+    enable_inbound_mysql_from_source        = optional(bool, false)
+    enable_outbound_http                    = optional(bool, false)
+    enable_outbound_from_custom_port_source = optional(bool, false)
+    enable_outbound_from_custom_port_cidr   = optional(bool, false)
+    enable_outbound_http_to_source          = optional(bool, false)
+    enable_outbound_https                   = optional(bool, false)
+    enable_outbound_https_to_source         = optional(bool, false)
+    enable_all_outbound_traffic             = optional(bool, false)
+    enable_all_outbound_traffic_to_source   = optional(bool, false)
+    source_security_group_id                = optional(string, null)
+    custom_port                             = optional(number, null)
+  }))
+  description = <<EOF
+  A list of objects that contains the configuration for the security groups, and that normally
+used in the context of ALB, testing traffic for ICMP packages, and other common use-cases
+It can be used as an alternative of the values that are set in the variable 'security_group_rules'.
+If set, it'll relate the sg_name with the 'name' attribute passed into the
+variable 'security_group_config'. The following attributes are supported:
+- sg_parent: The name of the security group.
+- enable_all_inbound_traffic: Whether to enable all inbound traffic or not.
+- enable_all_inbound_traffic_from_source: Whether to enable all inbound traffic from a specific source or not.
+- enable_inbound_http: Whether to enable inbound HTTP traffic or not.
+- enable_inbound_from_custom_port_source: Whether to enable inbound traffic from a specific source or not.
+- enable_inbound_from_custom_port_cidr: Whether to enable inbound traffic from a specific CIDR or not.
+- enable_inbound_http_from_source: Whether to enable inbound HTTP traffic from a specific source or not.
+- enable_inbound_https: Whether to enable inbound HTTPS traffic or not.
+- enable_inbound_https_from_source: Whether to enable inbound HTTPS traffic from a specific source or not.
+- enable_inbound_ssh_from_anywhere: Whether to enable inbound SSH traffic from anywhere or not.
+- enable_inbound_ssh_from_source: Whether to enable inbound SSH traffic from a specific source or not.
+- enable_inbound_icmp_from_source: Whether to enable inbound ICMP traffic from a specific source or not.
+- enable_inbound_icmp_from_anywhere: Whether to enable inbound ICMP traffic from anywhere or not.
+- enable_inbound_mysql_from_source: Whether to enable inbound MySQL traffic from a specific source or not.
+- enable_outbound_http: Whether to enable outbound HTTP traffic or not.
+- enable_outbound_from_custom_port_source: Whether to enable outbound traffic from a specific source or not.
+- enable_outbound_from_custom_port_cidr: Whether to enable outbound traffic from a specific CIDR or not.
+- enable_outbound_http_to_source: Whether to enable outbound HTTP traffic to a specific source or not.
+- enable_outbound_https: Whether to enable outbound HTTPS traffic or not.
+- enable_outbound_https_to_source: Whether to enable outbound HTTPS traffic to a specific source or not.
+- enable_all_outbound_traffic: Whether to enable all outbound traffic or not.
+- enable_all_outbound_traffic_to_source: Whether to enable all outbound traffic to a specific source or not.
+- source_security_group_id: The ID of the source security group.
+- custom_port: The custom port to use for the inbound/outbound traffic.
+  EOF
+  default     = null
+}

--- a/examples/security-group-v2/basic/versions.tf
+++ b/examples/security-group-v2/basic/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.48.0, < 5.0.0"
+    }
+    // FIXME: Remove, refactor or change. (Template)
+    random = {
+      source  = "hashicorp/random"
+      version = "3.4.3"
+    }
+  }
+}

--- a/modules/security-group-v2/.terraform-docs.yml
+++ b/modules/security-group-v2/.terraform-docs.yml
@@ -1,0 +1,64 @@
+---
+formatter: markdown table
+
+header-from: main.tf
+content: |-
+    # ☁️ AWS Security Group Module
+    ## Description
+    {{ .Header }}
+    This module provides a way to create a security group with a set of rules.
+    * 🚀 A security group, with standard rules.
+    * 🚀 A security group, with a set of rules.
+    This module is also capable of looking up for the VPC id if it's not provided. If the variable `vpc_id` is not provided, the module will use the values passed into the input variable 'var.vpc_lookup_config' to look for either the default VPC, or a named VPC using the tag 'Name' as its search criteria. If the VPC is not found, the module will throw an error.
+
+    ---
+    ## Example
+    Examples of this module's usage are available in the [examples](./examples) folder.
+
+    ```hcl
+    {{ include "../../examples/security-group/basic/main.tf" }}
+    ```
+
+    An example of multiple security groups, created at once:
+    ```hcl
+    {{ include "../../examples/security-group/basic/config/fixtures-multiple-only-sg.tfvars" }}
+    ```
+    An example of a security group that's created passing its VPC, as the default VPC:
+    ```hcl
+    {{ include "../../examples/security-group/basic/config/fixtures-with-default-vpc.tfvars" }}
+    ```
+    An example of a security group that's pointing or looking for a VPC with a specific name:
+    ```hcl
+    {{ include "../../examples/security-group/basic/config/fixtures-with-named-vpc.tfvars" }}
+    ```
+
+    For module composition, It's recommended to take a look at the module's `outputs` to understand what's available:
+    ```hcl
+    {{ include "outputs.tf" }}
+    ```
+    ---
+
+    ## Module's documentation
+    (This documentation is auto-generated using [terraform-docs](https://terraform-docs.io))
+    {{ .Providers }}
+
+    {{ .Modules }}
+
+    {{ .Resources }}
+
+    {{ .Requirements }}
+
+    {{ .Inputs }}
+
+    {{ .Outputs }}
+
+output:
+    file: README.md
+    mode: inject
+    template: |-
+        <!-- BEGIN_TF_DOCS -->
+        {{ .Content }}
+        <!-- END_TF_DOCS -->
+settings:
+    anchor: true
+    color: true

--- a/modules/security-group-v2/.tflint.hcl
+++ b/modules/security-group-v2/.tflint.hcl
@@ -1,0 +1,37 @@
+config {
+  module = true
+  force  = false
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.30.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+plugin "azurerm" {
+  enabled = true
+  version = "0.25.1"
+  source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}
+
+plugin "google" {
+  enabled = true
+  version = "0.27.1"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+rule "terraform_unused_required_providers" {
+  enabled = true
+}

--- a/modules/security-group-v2/README.md
+++ b/modules/security-group-v2/README.md
@@ -1,0 +1,79 @@
+<!-- BEGIN_TF_DOCS -->
+# ☁️ Example module
+## Description
+
+This module is used to demonstrate the how easy is to create a new terraform module. Here you usually describe the module's capabilities:
+* 🚀 Example capability or feature 1
+* 🚀 Example capability or feature 2
+
+---
+## Example
+Examples of this module's usage are available in the [examples](./examples) folder.
+
+```hcl
+module "main_module" {
+  source     = "../../../modules/default"
+  is_enabled = var.is_enabled
+}
+```
+
+For module composition, It's recommended to take a look at the module's `outputs` to understand what's available:
+```hcl
+output "is_enabled" {
+  value       = var.is_enabled
+  description = "Whether the module is enabled or not."
+}
+
+output "tags_set" {
+  value       = var.tags
+  description = "The tags set for the module."
+}
+
+/*
+-------------------------------------
+Custom outputs
+-------------------------------------
+*/
+// FIXME: Remove, refactor or change. (Template)
+```
+---
+
+## Module's documentation
+(This documentation is auto-generated using [terraform-docs](https://terraform-docs.io))
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [random_string.random_text](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/string) | resource |
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_is_enabled"></a> [is\_enabled](#input\_is\_enabled) | Whether this module will be created or not. It is useful, for stack-composite<br>modules that conditionally includes resources provided by this module.. | `bool` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_is_enabled"></a> [is\_enabled](#output\_is\_enabled) | Whether the module is enabled or not. |
+| <a name="output_tags_set"></a> [tags\_set](#output\_tags\_set) | The tags set for the module. |
+<!-- END_TF_DOCS -->

--- a/modules/security-group-v2/locals.tf
+++ b/modules/security-group-v2/locals.tf
@@ -1,0 +1,24 @@
+locals {
+  ###################################
+  # Feature Flags ⛳️
+  # ----------------------------------------------------
+  #
+  # These flags are used to enable or disable certain features.
+  # 1. `is_queue_enabled` - Flag to enable or disable the SQS queue that's built-in to the module.
+  # 2. `is_dlq_enabled` - Flag to enable or disable the Dead Letter Queue (DLQ) that's built-in to the module.
+  #
+  ###################################
+  is_enabled = var.is_enabled
+
+  ###################################
+  # Normalized & CLeaned Variables 🧹
+  # ----------------------------------------------------
+  #
+  # These variables are used to normalize and clean the input variables.
+  # 1. `queue_name` - The name of the queue. This is normalized to remove any leading or trailing whitespace.
+  # 2. `queue_name_fifo` - The name of the FIFO queue. This is normalized to remove any leading or trailing whitespace.
+  # 3. `dlq_name` - The name of the Dead Letter Queue (DLQ). This is normalized to remove any leading or trailing whitespace.
+  # 4. `dlq_name_fifo` - The name of the FIFO Dead Letter Queue (DLQ). This is normalized to remove any leading or trailing whitespace.
+  #
+  ###################################
+}

--- a/modules/security-group-v2/main.tf
+++ b/modules/security-group-v2/main.tf
@@ -1,0 +1,36 @@
+###################################
+# Module Resources 🛠️
+# ----------------------------------------------------
+#
+# This section declares the resources that will be created or managed by this Terraform module.
+# Each resource is annotated with comments explaining its purpose and any notable configurations.
+#
+###################################
+
+# Example resource: AWS SQS Queue
+# This resource demonstrates how to create a simple SQS queue with a random name.
+# The `for_each` is used to conditionally create resources based on the module's enabled state.
+
+resource "random_string" "random_text" {
+  for_each = local.is_enabled ? { example = true } : {}
+  length   = 10
+  special  = false
+}
+
+# Placeholder for actual resource implementation
+# Replace `random_string.random_text` with your desired resource and configuration.
+# Example:
+# resource "aws_sqs_queue" "example_queue" {
+#   for_each = local.is_enabled ? { "example" = true } : {}
+#
+#   name                      = "example-queue-${random_string.random_text.result}"
+#   delay_seconds             = 90
+#   max_message_size          = 2048
+#   message_retention_seconds = 86400
+#   receive_wait_time_seconds = 10
+#
+#   tags = var.tags
+# }
+
+# Add additional resources below following the same structure.
+# Remember to use descriptive names and include comments explaining the purpose and configuration of each resource.

--- a/modules/security-group-v2/outputs.tf
+++ b/modules/security-group-v2/outputs.tf
@@ -1,0 +1,31 @@
+output "is_enabled" {
+  value       = var.is_enabled
+  description = "Whether the module is enabled or not."
+}
+
+output "tags_set" {
+  value       = var.tags
+  description = "The tags set for the module."
+}
+
+###################################
+# Module-Specific Outputs 🚀
+# ----------------------------------------------------
+#
+# These outputs are specific to the functionality provided by this module.
+# They offer insights and access points into the resources created or managed by this module.
+#
+# (Add your module-specific outputs here, with a brief description for each)
+#
+###################################
+
+# Example of a module-specific output:
+# output "queue_url" {
+#   value       = aws_sqs_queue.main.url
+#   description = "The URL of the created SQS queue."
+# }
+
+# output "dlq_url" {
+#   value       = aws_sqs_queue.dlq.url
+#   description = "The URL of the created Dead Letter Queue (DLQ)."
+# }

--- a/modules/security-group-v2/variables.tf
+++ b/modules/security-group-v2/variables.tf
@@ -1,0 +1,31 @@
+###################################
+# Input Variables 🛠️
+# ----------------------------------------------------
+#
+# These variables allow users to customize the module according to their needs.
+# Each variable is documented with its description, type, and default value if applicable.
+#
+###################################
+
+variable "is_enabled" {
+  type        = bool
+  description = <<-DESC
+  Whether this module will be created or not. Useful for stack-composite
+  modules that conditionally include resources provided by this module.
+  DESC
+  default     = true
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to add to all resources."
+  default     = {}
+}
+
+# Add your additional variables here with a brief description, type, and default value if applicable.
+# Example:
+# variable "queue_name" {
+#   type        = string
+#   description = "The name of the SQS queue to be created."
+#   default     = null
+# }

--- a/modules/security-group-v2/versions.tf
+++ b/modules/security-group-v2/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.7.0"
+  required_providers {
+    #    aws = {
+    #      source  = "hashicorp/aws"
+    #      version = ">= 4.48.0, < 5.0.0"
+    #    }
+    // FIXME: Remove, refactor or change. (Template)
+    random = {
+      source  = "hashicorp/random"
+      version = "3.4.3"
+    }
+  }
+}


### PR DESCRIPTION
Added AWS provider configuration to set the region in providers.tf. Also added
input variables for enabling/disabling module, AWS region, tags, and custom
security group configurations in variables.tf. This allows for dynamic creation
and customization of security groups.